### PR TITLE
Add crossposting from Twitter to Mastodon

### DIFF
--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -195,7 +195,6 @@ ma_account_id = mastodon_api.account_verify_credentials()["id"]
 since_toot_id = mastodon_api.account_statuses(ma_account_id)[0]["id"]
 print("Tweeting any toots after toot " + str(since_toot_id))
 since_tweet_id = twitter_api.GetUserTimeline()[0].id
-since_tweet_id = 817816640859406336
 print("Tooting any tweets after tweet " + str(since_tweet_id))
 
 # Set "last URL length update" time to 1970


### PR DESCRIPTION
Adds basic functionality going the other way (note sure if MastodonToTwitter is a misnomer now).

Will replace t.co links with full, and download/upload media. Replies excluded, as are tweets/toots posted by the bridge.