### PR TITLE
Manage toot visibility and disable service repost

### DIFF
--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -21,11 +21,14 @@ import twitter
 POST_ON_MASTODON = True
 POST_ON_TWITTER = True
 
+# Manage visibility of your toot. Value are "private", "unlisted" or "public"
+TOOT_VISIBILITY = "unlisted"
+
 # How long to wait between polls to the APIs, in seconds
 API_POLL_DELAY = 30
 
 # The Mastodon instance base URL. By default, https://mastodon.social/
-MASTODON_BASE_URL = "https://hostux.social/"
+MASTODON_BASE_URL = "https://mastodon.social"
 
 # How often to retry when posting fails
 MASTODON_RETRIES = 3
@@ -385,12 +388,12 @@ while True:
                         # Toot
                         if len(media_ids) == 0:
                             print('Tooting "' + content_toot + '"...')
-                            post = mastodon_api.status_post(content_toot)
+                            post = mastodon_api.status_post(content_toot, visibility=TOOT_VISIBILITY)
                             since_toot_id = post["id"]
                             post_success = True
                         else:
                             print('Tooting "' + content_toot + '", with attachments...')
-                            post = mastodon_api.status_post(content_toot, media_ids=media_ids)
+                            post = mastodon_api.status_post(content_toot, media_ids=media_ids, visibility=TOOT_VISIBILITY)
                             since_toot_id = post["id"]
                             post_success = True
                     except:

--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -17,11 +17,15 @@ from builtins import input
 from mastodon import Mastodon
 import twitter
 
+# Enable repost on services
+POST_ON_MASTODON = True
+POST_ON_TWITTER = True
+
 # How long to wait between polls to the APIs, in seconds
 API_POLL_DELAY = 30
 
 # The Mastodon instance base URL. By default, https://mastodon.social/
-MASTODON_BASE_URL = "https://mastodon.social"
+MASTODON_BASE_URL = "https://hostux.social/"
 
 # How often to retry when posting fails
 MASTODON_RETRIES = 3
@@ -209,7 +213,9 @@ while True:
         print("Updated expected short URL length: Is now " + str(url_length))
         
     # Fetch new toots
-    new_toots = mastodon_api.account_statuses(ma_account_id, since_id = since_toot_id)
+    new_toots = []
+    if POST_ON_TWITTER:
+        new_toots = mastodon_api.account_statuses(ma_account_id, since_id = since_toot_id)
     if len(new_toots) != 0:
         since_toot_id = new_toots[0]["id"]
         new_toots.reverse()    
@@ -328,7 +334,9 @@ while True:
         print('Finished toot processing, resting until next toots.')
 
     # Fetch new tweets
-    new_tweets = twitter_api.GetUserTimeline(since_id = since_tweet_id, include_rts=False, exclude_replies=True)
+    new_tweets = []
+    if POST_ON_MASTODON:
+        new_tweets = twitter_api.GetUserTimeline(since_id = since_tweet_id, include_rts=False, exclude_replies=True)
     if len(new_tweets) != 0:
         since_tweet_id = new_tweets[0].id
 


### PR DESCRIPTION
Hi !
I added few line of code to allow user to disable the script from posting on one of the two services.
I made this to help user managing there account and help them prevent accidental post.
The other function I added was to create a TOOT_VISIBILITY variable that will make users be able to not publish everything they tweet on the public timeline.