### PR TITLE
FIX issue 15 Script crash if the mastodon acount has no toot #15

### DIFF
--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -199,7 +199,10 @@ twitter_api = twitter.Api(
 )
 
 ma_account_id = mastodon_api.account_verify_credentials()["id"]
-since_toot_id = mastodon_api.account_statuses(ma_account_id)[0]["id"]
+try:
+    since_toot_id = mastodon_api.account_statuses(ma_account_id)[0]["id"]
+except:
+    since_toot_id = 0
 print("Tweeting any toots after toot " + str(since_toot_id))
 since_tweet_id = twitter_api.GetUserTimeline()[0].id
 print("Tooting any tweets after tweet " + str(since_tweet_id))


### PR DESCRIPTION
Simple fix for Issue #15. Just prevents it from failing when no toot exists; once a toot exists, toots are sent to Twitter. Only tested once, just now, on my new Mastodon account.