### PR TITLE
Improvements for password and Mastodon server input.

### DIFF
--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -125,9 +125,9 @@ if not os.path.isfile("mtt_twitter.secret"):
 
         print("\n")
         if os.path.isfile("mtt_mastodon_server.secret"):
-            print("You already have mastodon server set up, so we're skipping that step.")
+            print("You already have Mastodon server set up, so we're skipping that step.")
         else:
-            print("Recording mastodon server...")
+            print("Recording Mastodon server...")
             try:
                 with open("mtt_mastodon_server.secret", "w") as mastodon_server:
                     mastodon_server.write(MASTODON_BASE_URL)

--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -124,6 +124,19 @@ if not os.path.isfile("mtt_twitter.secret"):
             MASTODON_BASE_URL = 'https://' + MASTODON_BASE_URL
 
         print("\n")
+        if os.path.isfile("mtt_mastodon_server.secret"):
+            print("You already have mastodon server set up, so we're skipping that step.")
+        else:
+            print("Recording mastodon server...")
+            try:
+                with open("mtt_mastodon_server.secret", "w") as mastodon_server:
+                    mastodon_server.write(MASTODON_BASE_URL)
+            except OSError as e:
+                print("... but it failed.", e)
+                sys.exit(-1)
+                mastodon_works = False
+
+        print("\n")
         if os.path.isfile("mtt_mastodon_client.secret"):
             print("You already have an app set up, so we're skipping that step.")
         else:
@@ -189,6 +202,10 @@ with open("mtt_twitter.secret", 'r') as secret_file:
     TWITTER_CONSUMER_SECRET = secret_file.readline().rstrip()
     TWITTER_ACCESS_KEY = secret_file.readline().rstrip()
     TWITTER_ACCESS_SECRET = secret_file.readline().rstrip()
+
+# Read in Mastodon server
+with open("mtt_mastodon_server.secret", 'r') as secret_file:
+    MASTODON_BASE_URL = secret_file.readline().rstrip()
 
 # Log in and start up
 mastodon_api = Mastodon(

--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -110,15 +110,13 @@ if not os.path.isfile("mtt_twitter.secret"):
 
     mastodon_works = False
     while mastodon_works == False:
-        MASTODON_BASE_URL = input("Mastodon server (e.g. mastodon.social): ").strip()
+        MASTODON_BASE_URL = input("Mastodon server (press Enter for mastodon.social): https://").strip()
         MASTODON_USERNAME = input("Mastodon Username (e-mail): ").strip()
         MASTODON_PASSWORD = getpass.getpass("Mastodon Password: ").strip()
 
         if MASTODON_BASE_URL == '':
             # The Mastodon instance base URL. By default, https://mastodon.social/
             MASTODON_BASE_URL = "https://mastodon.social"
-        elif not MASTODON_BASE_URL.startswith('https://'):
-            MASTODON_BASE_URL = 'https://' + MASTODON_BASE_URL
 
         print("\n")
         if os.path.isfile("mtt_mastodon_server.secret"):

--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -37,9 +37,6 @@ TWITTER_RETRIES = 3
 MASTODON_RETRY_DELAY = 20
 TWITTER_RETRY_DELAY = 20
 
-# Media regex, to trim media URLs
-MASTODON_BASE_URL = ''
-
 # Some helpers copied out from python-twitter, because they're broken there
 URL_REGEXP = re.compile((
     r'('

--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -110,11 +110,11 @@ if not os.path.isfile("mtt_twitter.secret"):
 
     mastodon_works = False
     while mastodon_works == False:
-        MASTODON_BASE_URL = input("Mastodon server (press Enter for mastodon.social): https://").strip()
+        MASTODON_BASE_URL = 'https://' + input("Mastodon server (press Enter for mastodon.social): https://").strip()
         MASTODON_USERNAME = input("Mastodon Username (e-mail): ").strip()
         MASTODON_PASSWORD = getpass.getpass("Mastodon Password: ").strip()
 
-        if MASTODON_BASE_URL == '':
+        if MASTODON_BASE_URL == 'https://':
             # The Mastodon instance base URL. By default, https://mastodon.social/
             MASTODON_BASE_URL = "https://mastodon.social"
 


### PR DESCRIPTION
This PR fixes #21. In addition, password should be input via `getpass.getpass()`. It is very terrible when you're typing password in plaintext, stored in terminal. This PR fixes that.