### PR TITLE
Makes media from twitter not sensitive (fixes #26)

### DIFF
--- a/MastodonToTwitter.py
+++ b/MastodonToTwitter.py
@@ -416,7 +416,7 @@ while True:
                             post_success = True
                         else:
                             print('Tooting "' + content_toot + '", with attachments...')
-                            post = mastodon_api.status_post(content_toot, media_ids=media_ids, visibility=TOOT_VISIBILITY)
+                            post = mastodon_api.status_post(content_toot, media_ids=media_ids, visibility=TOOT_VISIBILITY, sensitive=None)
                             since_toot_id = post["id"]
                             post_success = True
                     except:


### PR DESCRIPTION
In my opinion media from twitter should not be marked sensitive by default.
This fixes the same bug as in Mastodon.py
(https://github.com/halcy/Mastodon.py/issues/20) until a new version is released
and people update their machines.