### PR TITLE
Fix requirements.txt for issue #50

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Mastodon.py>=1.0.6
+Mastodon.py>=1.0.6,<=1.0.7
 python-twitter>=3.2


### PR DESCRIPTION
MastodonToTwitter does not work with the latest version of Mastodon.py, this PR updates requirements.txt about that.