### PR TITLE
Fix "No such file or directory: 'git'" on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /usr/src/app
 
 # Copy Source and requirements
 ADD ["requirements.txt", "__init__.py", "mtt/", "/usr/src/app/"]
-RUN pip3 install --no-cache-dir -r requirements.txt && \
+RUN apk add --no-cache git && \
+    pip3 install --no-cache-dir -r requirements.txt && \
     touch mtt_mastodon_client.secret \
           mtt_mastodon_user.secret \
           mtt_mastodon_server.secret \


### PR DESCRIPTION
Docker build fails when `pip install` without git. Fixed by adding `apk add git` in Dockerfile.